### PR TITLE
Convert Japanese error messages to English

### DIFF
--- a/aa-front/app/contexts/UserOpConfirmationContext.tsx
+++ b/aa-front/app/contexts/UserOpConfirmationContext.tsx
@@ -70,7 +70,7 @@ export function UserOpConfirmationProvider({ children }: { children: ReactNode }
     if (isProcessing) return
 
     if (confirmReject) {
-      confirmReject(new Error('ユーザーが操作をキャンセルしました'))
+      confirmReject(new Error('User cancelled the operation'))
     }
 
     setIsModalOpen(false)

--- a/aa-front/app/hooks/useEstimateUserOperationGas.ts
+++ b/aa-front/app/hooks/useEstimateUserOperationGas.ts
@@ -70,7 +70,7 @@ export function useEstimateUserOperationGas() {
         totalGasEth,
       }
     } catch (error) {
-      console.warn('ガス推定に失敗しました、デフォルト値を使用します:', error)
+      console.warn('Gas estimation failed, using default values:', error)
       return {
         userOpResult: userOp,
         totalGasWei: BigInt(0),

--- a/aa-front/app/hooks/useUserOpExecutor.ts
+++ b/aa-front/app/hooks/useUserOpExecutor.ts
@@ -205,7 +205,7 @@ export function useUserOperationExecutor(aaAddress: Hex) {
             preVerificationGas: userOpResult.preVerificationGas,
           }
         } catch (estimateError) {
-          console.warn('ガス推定に失敗しました:', estimateError)
+          console.warn('Gas estimation failed:', estimateError)
           // エラーが発生しても続行（情報なしで）
         }
 
@@ -259,11 +259,11 @@ export function useUserOperationExecutor(aaAddress: Hex) {
 
         return result
       } catch (error) {
-        console.error('UserOperation実行中にエラーが発生しました:', error)
+        console.error('An error occurred during UserOperation execution:', error)
         completeOperation(false)
         return {
           success: false,
-          error: error instanceof Error ? error.message : '不明なエラーが発生しました',
+          error: error instanceof Error ? error.message : 'An unknown error occurred',
         }
       }
     },


### PR DESCRIPTION
Resolves #15

Converted 5 Japanese error messages to natural English while preserving all Japanese comments as requested.

## Changes
- Converted console.warn and console.error messages to English
- Converted error object messages to English
- Preserved all Japanese comments throughout the codebase
- Improved error message clarity for international developers

## Files Changed
- `aa-front/app/hooks/useEstimateUserOperationGas.ts`
- `aa-front/app/hooks/useUserOpExecutor.ts`
- `aa-front/app/contexts/UserOpConfirmationContext.tsx`

Generated with [Claude Code](https://claude.ai/code)