### PR TITLE
Fix: Specify '0.0.0.0' for listening address in Docker environment

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -3,8 +3,10 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
-const PORT = process.env.PORT || 4000
+const PORT = Number(process.env.PORT) || 4000
 
-app.listen(PORT, () => {
+// 0.0.0.0を指定することで、サーバーはすべてのネットワークインターフェース（IPv4）でリクエストを受けつける
+// Dockerのコンテナ環境で実行する場合、0.0.0.0は必須
+app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server running on port ${PORT}`)
 })


### PR DESCRIPTION
This change ensures the server listens on all network interfaces (IPv4) by specifying '0.0.0.0' as the listening address. This is necessary for Docker container environments to properly receive requests. Also, this change ensures that the PORT is a number.